### PR TITLE
fix: completion generation for Fish

### DIFF
--- a/src/uv/install.sh
+++ b/src/uv/install.sh
@@ -163,7 +163,7 @@ enable_autocompletion() {
         echo "eval \"\$(${command} zsh)\"" >> $_REMOTE_USER_HOME/.zshrc
     fi
     if [ -f "$_REMOTE_USER_HOME/.config/fish/config.fish" ]; then
-        echo "${command} fish | source" >> $_REMOTE_USER_HOME/.config/fish/config.fish
+        echo "${command} fish" >> $_REMOTE_USER_HOME/.config/fish/config.fish
     fi
     if [ -f "$_REMOTE_USER_HOME/.elvish/rc.elv" ]; then
         echo "eval (${command} elvish | slurp)" >> $_REMOTE_USER_HOME/.elvish/rc.elv


### PR DESCRIPTION
First things first: Thank you for creating this feature, I find it quite useful

I'm a Fish Shell user, and I noted that the `uv` completion was not working, after looking at the code and test in my computer, I solved it removing the `source` command from the pipe.

Here is the template that I used to test the feature as it is right now:

```json
{
	"name": "Python",
	"image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
	"features": {
		"ghcr.io/va-h/devcontainers-features/uv:1": {"shellautocompletion": true},
		"ghcr.io/meaningful-ooo/devcontainer-features/fish:1": {}
	}
}
```

The following command did not work on an out of the box fish shell:

```fish
uv generate-shell-completion fish | source >> /home/vscode/.config/fish/config.fish
```

But this one did:

```fish
uv generate-shell-completion fish >> /home/vscode/.config/fish/config.fish
```