### PR TITLE
Fix uv completions on fish

### DIFF
--- a/src/uv/NOTES.md
+++ b/src/uv/NOTES.md
@@ -2,10 +2,13 @@
 
 * [astral-sh/uv](https://github.com/astral-sh/uv)
 
-## Autocompletion for other shells than Bash
+## Fix Autocompletion with feature Shells
 
-When installing a shell via another feature, make sure to override the installation order to make sure that the autocomplatetion takes place. Here is an example installing the Fish shell and enabling autocompletion for it:
+> [!IMPORTANT]
+> When installing a shell via another feature, make sure to override the installation order to ensure the generated autocompletion writes to existing files.
 
+### Autocompletion for Fish Shell
+ 
 ```json
 "features": {
     "ghcr.io/meaningful-ooo/devcontainer-features/fish:latest": {},

--- a/src/uv/NOTES.md
+++ b/src/uv/NOTES.md
@@ -1,3 +1,20 @@
 ## uv Repository
 
 * [astral-sh/uv](https://github.com/astral-sh/uv)
+
+## Autocompletion for other shells than Bash
+
+When installing a shell via another feature, make sure to override the installation order to make sure that the autocomplatetion takes place. Here is an example installing the Fish shell and enabling autocompletion for it:
+
+```json
+"features": {
+    "ghcr.io/meaningful-ooo/devcontainer-features/fish:latest": {},
+    "ghcr.io/va-h/devcontainers-features/uv:latest": {
+        "shellautocompletion": true
+    }
+},
+"overrideFeatureInstallOrder": [
+    "ghcr.io/meaningful-ooo/devcontainer-features/fish",
+    "ghcr.io/va-h/devcontainers-features/uv:latest"
+]
+```

--- a/src/uv/devcontainer-feature.json
+++ b/src/uv/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "uv",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "name": "uv",
     "documentationURL": "http://github.com/va-h/devcontainers-features/tree/main/src/uv",
     "description": "An extremely fast Python package and project manager, written in Rust.",

--- a/src/uv/install.sh
+++ b/src/uv/install.sh
@@ -162,8 +162,9 @@ enable_autocompletion() {
     if [ -f "$_REMOTE_USER_HOME/.zshrc" ]; then
         echo "eval \"\$(${command} zsh)\"" >> $_REMOTE_USER_HOME/.zshrc
     fi
-    if [ -f "$_REMOTE_USER_HOME/.config/fish/config.fish" ]; then
-        echo "${command} fish" >> $_REMOTE_USER_HOME/.config/fish/config.fish
+    if [ -d "$_REMOTE_USER_HOME/.config/fish" ]; then
+        mkdir -p $_REMOTE_USER_HOME/.config/fish/completions
+        ${command} fish >> $_REMOTE_USER_HOME/.config/fish/completions/uv.fish
     fi
     if [ -f "$_REMOTE_USER_HOME/.elvish/rc.elv" ]; then
         echo "eval (${command} elvish | slurp)" >> $_REMOTE_USER_HOME/.elvish/rc.elv


### PR DESCRIPTION
Hi,

I realised that the fix I submitted previously was actually not fixing anything. This time I've made some more testing to make sure it works. This is the `.devcontainer.json` used for my tests after making a local copy of the feature source code:

```json
{
	"name": "Python",
	"image": "mcr.microsoft.com/devcontainers/python:1-3.13-bookworm",
	"features": {
		"ghcr.io/meaningful-ooo/devcontainer-features/fish:latest": {},
		"./uv": {
			"shellautocompletion": true
		}
	},
	"overrideFeatureInstallOrder": [
		"ghcr.io/meaningful-ooo/devcontainer-features/fish",
		"./uv"
	]
}
```

I added some debug traces with `echo` to `install.sh` and discovered that:

1. Without overriding the installation order, the `uv` feature may be installed before `fish`, and then the auto completion `config.fish` check fails.
2. The file `config.fish` does not exist even when `fish` shell has been installed before `uv`. However, the `$HOME/.config/fish` folder does exist.

The `mkdir -p` command is probably not necessary. During debugging the `completions` folder already existed, but I thought it would be a good "just in case".

The completions are saved into its own file, the [fish documentation](https://fishshell.com/docs/current/completions.html#where-to-put-completions) suggests that it helps to keep things tidy.

An alternative way to address the generation of the auto completion, would be to generate the completions for all the shells, and put them in a system wide location. In the case of fish, this could be `/etc/fish/completions`. Maybe other shells have a similar way to keep them.

As a side note, for debugging the builds of my `.devcontainer.json` I used the following commands (fish shell syntax):

```fish
# Change how build logs are shown in the terminal
> set -xU BUILDKIT_PROGRESS plain
# Build using the devcontainer-cli
> devcontainer build --workspace-folder (pwd) --log-level debug --no-cache
```

I'm quite new to the development of devcontainer's features and templates. If you have comments or suggestions about how to do things, the feedback is welcome :-)