### PR TITLE
Generate completions globally

### DIFF
--- a/src/uv/NOTES.md
+++ b/src/uv/NOTES.md
@@ -1,23 +1,3 @@
 ## uv Repository
 
 * [astral-sh/uv](https://github.com/astral-sh/uv)
-
-## Fix Autocompletion with feature Shells
-
-> [!IMPORTANT]
-> When installing a shell via another feature, make sure to override the installation order to ensure the generated autocompletion writes to existing files.
-
-### Autocompletion for Fish Shell
- 
-```json
-"features": {
-    "ghcr.io/meaningful-ooo/devcontainer-features/fish:latest": {},
-    "ghcr.io/va-h/devcontainers-features/uv:latest": {
-        "shellautocompletion": true
-    }
-},
-"overrideFeatureInstallOrder": [
-    "ghcr.io/meaningful-ooo/devcontainer-features/fish",
-    "ghcr.io/va-h/devcontainers-features/uv:latest"
-]
-```

--- a/src/uv/install.sh
+++ b/src/uv/install.sh
@@ -156,16 +156,9 @@ uv --version
 
 enable_autocompletion() {
     command=$1
-    if [ -f "$_REMOTE_USER_HOME/.bashrc" ]; then
-        echo "eval \"\$(${command} bash)\"" >> $_REMOTE_USER_HOME/.bashrc
-    fi
-    if [ -f "$_REMOTE_USER_HOME/.zshrc" ]; then
-        echo "eval \"\$(${command} zsh)\"" >> $_REMOTE_USER_HOME/.zshrc
-    fi
-    if [ -d "$_REMOTE_USER_HOME/.config/fish" ]; then
-        mkdir -p $_REMOTE_USER_HOME/.config/fish/completions
-        ${command} fish >> $_REMOTE_USER_HOME/.config/fish/completions/uv.fish
-    fi
+    ${command} bash >> /usr/share/bash-completion/completions/uv
+    ${command} zsh >> /usr/share/zsh/vendor-completions/_uv
+    ${command} fish >> /usr/share/fish/completions/uv.fish
     if [ -f "$_REMOTE_USER_HOME/.elvish/rc.elv" ]; then
         echo "eval (${command} elvish | slurp)" >> $_REMOTE_USER_HOME/.elvish/rc.elv
     fi

--- a/src/uv/install.sh
+++ b/src/uv/install.sh
@@ -159,9 +159,6 @@ enable_autocompletion() {
     ${command} bash >> /usr/share/bash-completion/completions/uv
     ${command} zsh >> /usr/share/zsh/vendor-completions/_uv
     ${command} fish >> /usr/share/fish/completions/uv.fish
-    if [ -f "$_REMOTE_USER_HOME/.elvish/rc.elv" ]; then
-        echo "eval (${command} elvish | slurp)" >> $_REMOTE_USER_HOME/.elvish/rc.elv
-    fi
 }
 
 if [ "$AUTOCOMPLETION"  = "true" ]; then

--- a/test/uv/scenarios.json
+++ b/test/uv/scenarios.json
@@ -8,7 +8,7 @@
         }
     },
     "uv-autocomplete": {
-        "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+        "image": "mcr.microsoft.com/devcontainers/base:debian",
         "features": {
             "ghcr.io/devcontainers/features/common-utils:2.5.2": {
                 "installZsh": true,

--- a/test/uv/uv-autocomplete.sh
+++ b/test/uv/uv-autocomplete.sh
@@ -9,8 +9,9 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "uv autocomplete bash" cat ~/.bashrc | grep "eval \"\$(uv" | grep bash
-check "uv autocomplete zsh" cat ~/.zshrc | grep "eval \"\$(uv" | grep zsh
+check "uv autocomplete bash" [ -e /usr/share/bash-completion/completions/uv ]
+check "uv autocomplete zsh"  [ -e /usr/share/zsh/vendor-completions/_uv ]
+check "uv autocomplete fish" [ -e /usr/share/fish/completions/uv.fish ]
 
 # Report results
 # If any of the checks above exited with a non-zero exit code, the test will fail.


### PR DESCRIPTION
Hi,

After our previous conversation in #8 , I thought that would be nice to install all the completions globally. In that way, the user does not have to keep in mind the order of the features.

I have tested this with `bash`, `zsh` and `fish`. As I could not find a devcontainer feature for elvish, I left the code for that shell untouched. 

Let me know what you think.